### PR TITLE
Fixes for GoogleGeocoder that don't work on HEAD

### DIFF
--- a/modules/locationtextfield/src/main/java/org/vaadin/addons/locationtextfield/GoogleGeocoder.java
+++ b/modules/locationtextfield/src/main/java/org/vaadin/addons/locationtextfield/GoogleGeocoder.java
@@ -52,7 +52,7 @@ public final class GoogleGeocoder extends URLConnectionGeocoder {
     }
 
     protected String getURL(String address) throws UnsupportedEncodingException {
-        return (this.useSecureConnection ? SECURE_URL : INSECURE_URL) + "?address=" + URLEncoder.encode(address, "UTF-8");
+        return (this.useSecureConnection ? SECURE_URL : INSECURE_URL) + "?address=" + URLEncoder.encode(address, "UTF-8") + "&sensor=false";
     }
 
     protected Collection<? extends GeocodedLocation> createLocations(String address, String input) throws GeocodingException {
@@ -93,7 +93,7 @@ public final class GoogleGeocoder extends URLConnectionGeocoder {
                     }
                     JSONObject location = result.getJSONObject("geometry").getJSONObject("location");
                     loc.setLat(location.getDouble("lat"));
-                    loc.setLon(location.getDouble("lon"));
+                    loc.setLon(location.getDouble("lng"));
                     loc.setType(getLocationType(result));
                     locations.add(loc);
                 }


### PR DESCRIPTION
Several issues detected,
- the longitude attribute was mistakenly named lon instead of lng
- google (now?) requires a sensor attribute (which does not seem to make sense in non-reverse geocoding)

Feel free to comment if you think I'm mistaken (tested ok in my project)

Also, please consider getting rid of the singleton static approach which, because of the private constructor, forces 
